### PR TITLE
ADR043 Use Docker as container runtime

### DIFF
--- a/doc/PSI/PSI-ADR/Accepted/ADR043-use-docker-as-container-runner.md
+++ b/doc/PSI/PSI-ADR/Accepted/ADR043-use-docker-as-container-runner.md
@@ -1,0 +1,40 @@
+# Use Docker as Container Runner
+
+- ID: ADR043
+- Status: :accepted:
+- Deciders: @wr @hop @sst
+- Date: 2026-07-22
+- Version 1.0
+- Category: Architecture
+
+## Context and Problem Statement
+
+The PSI project uses self-hosted GitHub Action Runners to execute Continuous Integration (CI) workflows that require certain internal tooling (RHOD).
+
+To improve security and isolation, execution inside a container will be enforced (`ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=true`).
+
+Docker and Podman were considered as possible OCI-compliant container runtimes. While both can execute containers, GitHub Actions and the GitHub Actions Runner have been designed primarily around Docker.
+
+Many GitHub Actions invoke the Docker CLI directly or rely on Docker-specific behavior. Although Podman provides a Docker-compatible interface, compatibility is not guaranteed for all actions and requires additional validation and maintenance.
+
+## Decision Drivers
+
+- Security
+- Complexity of integrating with the CGI internal container registry
+- GitHub action runner support
+
+## Considered Options
+
+- Docker
+- Podman
+
+## Decision Outcome
+
+Podman is, in most cases, a drop-in replacement for Docker. However, some small details differ during execution. The GitHub action runner depends on some of these differences.
+Use Docker as the container runtime for our self-hosted GitHub action runner.
+
+Revisit this once Podman is supported by GitHub Action runners, see [GitHub actions runner issue](https://github.com/actions/runner/issues/505).
+
+## Compliance
+
+Docker will be installed on the internal CGI GitHub action runner.

--- a/doc/PSI/PSI-ADR/Accepted/list-of-decisions.md
+++ b/doc/PSI/PSI-ADR/Accepted/list-of-decisions.md
@@ -56,3 +56,5 @@
 @include [ADR041 MEF Convergence](ADR041-mef-convergence.md)
 
 @include [ADR042 Advanced OpenAPI Specification Patching](ADR042-advanced-oas-patching.md)
+
+@include [ADR043 Use Docker as Container Runner](ADR043-use-docker-as-container-runner.md)


### PR DESCRIPTION
This adds ADR043 to PSI-ADR to document the decision to use Docker as the container runtime.