### PR TITLE
Document GLFM Clean-up

### DIFF
--- a/doc/PSI/PSI-ADR/attic.md
+++ b/doc/PSI/PSI-ADR/attic.md
@@ -2,8 +2,6 @@
 
 # :book: ​Information for contributors - not included into final document
 
-[[_TOC_]]
-
 Documents referenced in this page:
 
 * PSI-ADR

--- a/doc/PSI/PSI-ADR/index.md
+++ b/doc/PSI/PSI-ADR/index.md
@@ -2,8 +2,6 @@
 
 # :book: ​Information for contributors - not included into final document
 
-[[_TOC_]]
-
 Documents referenced in this page:
 
 * PSI-MADR

--- a/doc/PSI/PSI-CST/casestudy.md
+++ b/doc/PSI/PSI-CST/casestudy.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # PSS Case Study
 
 > The heading has to be included in the document that includes this document.

--- a/doc/PSI/PSI-CST/index.md
+++ b/doc/PSI/PSI-CST/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-CST/userstory.md
+++ b/doc/PSI/PSI-CST/userstory.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # A User Story: Demonstration of capabilities
 
 > The heading has to be included in the document that includes this document.

--- a/doc/PSI/PSI-DAC/aitf.md
+++ b/doc/PSI/PSI-DAC/aitf.md
@@ -2,8 +2,6 @@
 
 # Automation of requirements traceability
 
-[[_TOC_]]
-
 =end
 
 Requirements serve as foundation to define functionalities an envisioned software shall have and also the constraints the software shall express.

--- a/doc/PSI/PSI-DAC/index.md
+++ b/doc/PSI/PSI-DAC/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-DAC/llm-conformance-docs.md
+++ b/doc/PSI/PSI-DAC/llm-conformance-docs.md
@@ -2,8 +2,6 @@
 
 ### Auto-generating Conformance documentation
 
-[[_TOC_]]
-
 =end
 
 Mistral was asked first to analyze the provided PDF Conformance documents for their structure and similarities:

--- a/doc/PSI/PSI-DAC/llm-userguide-docs.md
+++ b/doc/PSI/PSI-DAC/llm-userguide-docs.md
@@ -2,8 +2,6 @@
 
 ### Auto-generating Userguide documentation
 
-[[_TOC_]]
-
 =end
 
 Again, Mistral was asked first to analyze the provided pdf documents for their structure and similarities:

--- a/doc/PSI/PSI-DAC/llm.md
+++ b/doc/PSI/PSI-DAC/llm.md
@@ -2,8 +2,6 @@
 
 # Large Language Models and Document Generation
 
-[[_TOC_]]
-
 =end
 
 ## Introduction

--- a/doc/PSI/PSI-DAC/oas-transformation.md
+++ b/doc/PSI/PSI-DAC/oas-transformation.md
@@ -2,8 +2,6 @@
 
 # Automated Generation of OpenAPI Specification files
 
-[[_TOC_]]
-
 =end
 
 ## OpenAPI Specification files

--- a/doc/PSI/PSI-DAC/outlook.md
+++ b/doc/PSI/PSI-DAC/outlook.md
@@ -2,8 +2,6 @@
 
 # Automation of document generation - Conclusion
 
-[[_TOC_]]
-
 =end
 
 We have shown how PSI uses Documentation as Code within its repository.

--- a/doc/PSI/PSI-DAC/rhod.md
+++ b/doc/PSI/PSI-DAC/rhod.md
@@ -2,8 +2,6 @@
 
 # DaC application in PSID
 
-[[_TOC_]]
-
 =end
 
 In the context of the PSID project, we have adapted DaC to take advantage of the benefits described above.

--- a/doc/PSI/PSI-GID/cga.md
+++ b/doc/PSI/PSI-GID/cga.md
@@ -2,8 +2,6 @@
 
 # CGA
 
-[[_TOC_]]
-
 =end
 
 ## Distributed Matchmaking

--- a/doc/PSI/PSI-GID/index.md
+++ b/doc/PSI/PSI-GID/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-GID/mission-oda.md
+++ b/doc/PSI/PSI-GID/mission-oda.md
@@ -2,8 +2,6 @@
 
 # Mission Management ODA Component GUI
 
-[[*TOC*]]
-
 =end
 
 The development of a mission management ODA component, which we are aiming to publish on GitHub, is an important target for PSI.

--- a/doc/PSI/PSI-GID/provider-GUI.md
+++ b/doc/PSI/PSI-GID/provider-GUI.md
@@ -2,8 +2,6 @@
 
 # Provider Journey
 
-[[*TOC*]]
-
 =end
 
 To interact with the system, the provider needs a graphical interface.

--- a/doc/PSI/PSI-GID/user-GUI.md
+++ b/doc/PSI/PSI-GID/user-GUI.md
@@ -2,8 +2,6 @@
 
 # User Journey
 
-[[*TOC*]]
-
 =end
 
 ## Mission Creation

--- a/doc/PSI/PSI-ICD/characteristics.md
+++ b/doc/PSI/PSI-ICD/characteristics.md
@@ -2,8 +2,6 @@
 
 # Types and Characteristics
 
-[[_TOC_]]
-
 =end
 
 The PSS defines a set of supported types for resources, services and products in consultation with the providers.

--- a/doc/PSI/PSI-ICD/index.md
+++ b/doc/PSI/PSI-ICD/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-ICD/security.md
+++ b/doc/PSI/PSI-ICD/security.md
@@ -1,7 +1,5 @@
 =begin
 
-[[_TOC_]]
-
 # Security Considerations
 
 =end

--- a/doc/PSI/PSI-READFIRST/index.md
+++ b/doc/PSI/PSI-READFIRST/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-REQ/index.md
+++ b/doc/PSI/PSI-REQ/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-REQ/psid_requirements.md
+++ b/doc/PSI/PSI-REQ/psid_requirements.md
@@ -2,8 +2,6 @@
 
 # PSID Requirements
 
-[[_TOC_]]
-
 =end
 
 # REQ-01-Miscellaneous

--- a/doc/PSI/PSI-REQ/requirement_categories.md
+++ b/doc/PSI/PSI-REQ/requirement_categories.md
@@ -2,8 +2,6 @@
 
 # Requirement Categories
 
-[[_TOC_]]
-
 =end
 
 For clarity and ease of use, all PSI requirements are grouped by the corresponding endpoint of the interface and then enumerated corresponding to the [PSI-TOD].

--- a/doc/PSI/PSI-SLF/index.md
+++ b/doc/PSI/PSI-SLF/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-TAD/abbreviations.md
+++ b/doc/PSI/PSI-TAD/abbreviations.md
@@ -1,5 +1,4 @@
 =begin
-[[_TOC_]]
 
 # Abbreviations
 

--- a/doc/PSI/PSI-TAD/index.md
+++ b/doc/PSI/PSI-TAD/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-TAD/preamble.md
+++ b/doc/PSI/PSI-TAD/preamble.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # Preamble
 
 =end

--- a/doc/PSI/PSI-TAD/terms.md
+++ b/doc/PSI/PSI-TAD/terms.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # Terminology
 
 =end

--- a/doc/PSI/PSI-TOD/how_to_read_this_document.md
+++ b/doc/PSI/PSI-TOD/how_to_read_this_document.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # How To Read This Document
 
 =end

--- a/doc/PSI/PSI-TOD/index.md
+++ b/doc/PSI/PSI-TOD/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](../common/common_metadata.md)
 
 =begin metadata

--- a/doc/PSI/PSI-TOD/preamble.md
+++ b/doc/PSI/PSI-TOD/preamble.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # Preamble
 
 =end

--- a/doc/PSI/PSI-TOD/tasks_and_operations.md
+++ b/doc/PSI/PSI-TOD/tasks_and_operations.md
@@ -2,8 +2,6 @@
 
 # :book: wiki-Internal section, not compiled to documents
 
-[[_TOC_]]
-
 # Tasks and Operations
 
 =end

--- a/doc/PSI/common/development_state.md
+++ b/doc/PSI/common/development_state.md
@@ -1,4 +1,4 @@
 
 # Development State
 
-Current document version is `1.3.0`.  
+Current document version is `2.0.0-alpha`.

--- a/doc/PSI/common/release_notes.md
+++ b/doc/PSI/common/release_notes.md
@@ -1,9 +1,3 @@
-# Release Notes
-
-[[_TOC_]]
-
----
-
 # PSI Release Notes
 
 ## Introduction

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,3 @@
-=begin
-[[_TOC_]]
-=end
-
 @include [common meta information like version docdate etc..](PSI/common/common_metadata.md)
 
 =begin metadata


### PR DESCRIPTION
This:
- removes [GitLab flavored markdown](https://docs.gitlab.com/user/markdown/) `[[_TOC_]]`s from our documents
- Sets the correct document version in `development_state.md`
- Removes the toc-section in `release_notes.md`