### PR TITLE
Fix Unit Test Execution

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,6 +10,11 @@ jobs:
         name: Build
         uses: ./.github/workflows/build.yml
 
+    unit_tests:
+        name: Unit Tests
+        needs: build
+        uses: ./.github/workflows/unit-tests.yml
+
     code_docs:
         name: Code Documentation
         needs: build

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -10,6 +10,7 @@ jobs:
             pull-requests: read
         outputs:
             code: ${{ steps.filter.outputs.code }}
+            testdata: ${{ steps.filter.outputs.testdata }}
             documents: ${{ steps.filter.outputs.documents }}
         steps:
             - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -23,8 +24,11 @@ jobs:
                         - 'Taskfile.check.yml'
                         - 'build.gradle'
                         - 'settings.gradle'
+                        - 'gradle.properties'
                         - 'buildSrc/**/*.{java,gradle,groovy}'
                         - 'source/**/*.{java,gradle,yml,config,json,toml,sql,py}'
+                      testdata:
+                        - 'aiv/testing/testdata/**'
                       documents:
                         - 'Taskfile.yml'
                         - 'aiv/rhod/Taskfile.yml'
@@ -44,6 +48,14 @@ jobs:
         needs: changes
         if: ${{ needs.changes.outputs.code == 'true' }}
         uses: ./.github/workflows/build.yml
+
+    unit_tests:
+        name: Unit Tests
+        needs:
+            - changes
+            - build
+        if: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.testdata == 'true' }}
+        uses: ./.github/workflows/unit-tests.yml
 
     code_docs:
         name: Code Documentation Test Build

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -10,6 +10,11 @@ jobs:
         name: Release Build
         uses: ./.github/workflows/build.yml
 
+    unit_tests:
+        name: Unit Tests
+        needs: build
+        uses: ./.github/workflows/unit-tests.yml
+
     code_docs:
         name: Code Documentation Release Build
         needs: build
@@ -26,6 +31,7 @@ jobs:
         runs-on: ubuntu-latest
         needs:
             - build
+            - unit_tests
             - code_docs
             - document_build
         permissions:

--- a/aiv/testing/testdata/partyIndividuals/party_individuals.json
+++ b/aiv/testing/testdata/partyIndividuals/party_individuals.json
@@ -1,0 +1,30 @@
+[
+  {
+    "givenName": "Mira",
+    "familyName": "Keller",
+    "name": "Mira Keller",
+    "partyCharacteristic": [
+      {
+        "name": "maxPriority",
+        "valueType": "string",
+        "value": "HIGH",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "@type": "Individual"
+  },
+  {
+    "givenName": "Daniel",
+    "familyName": "Novak",
+    "name": "Daniel Novak",
+    "partyCharacteristic": [
+      {
+        "name": "maxPriority",
+        "valueType": "string",
+        "value": "LOW",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "@type": "Individual"
+  }
+]

--- a/aiv/testing/testdata/partyOrganizations/party_organizations.json
+++ b/aiv/testing/testdata/partyOrganizations/party_organizations.json
@@ -1,0 +1,212 @@
+[
+  {
+    "name": "Aurora Relay",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "mira_keller",
+          "name": "Mira Keller",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Blue Meridian",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "daniel_novak",
+          "name": "Daniel Novak",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Northstar Signal",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "mira_keller",
+          "name": "Mira Keller",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Cedar Orbit",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "daniel_novak",
+          "name": "Daniel Novak",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Vela Connect",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "mira_keller",
+          "name": "Mira Keller",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Solstice Array",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "daniel_novak",
+          "name": "Daniel Novak",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Harbor Vector",
+    "@type": "Organization",
+    "partyCharacteristic": [
+      {
+        "name": "orderResponseTime",
+        "valueType": "string",
+        "value": "PT12H",
+        "@type": "StringCharacteristic"
+      },
+      {
+        "name": "inquiryResponseTime",
+        "valueType": "string",
+        "value": "PT24H",
+        "@type": "StringCharacteristic"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyOrPartyRole",
+        "role": "Operator",
+        "partyOrPartyRole": {
+          "id": "mira_keller",
+          "name": "Mira Keller",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ]
+  }
+]

--- a/aiv/testing/testdata/productOfferings/aurora_relay_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/aurora_relay_productOffering.json
@@ -1,0 +1,242 @@
+[
+  {
+    "name": "Horizon Aurora Access Core Offering",
+    "description": "Commercial offering for Horizon Aurora Access Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "horizon_aurora_access_core",
+      "name": "Horizon Aurora Access Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "horizon_aurora_access_core_managed_service",
+      "name": "Horizon Aurora Access Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "horizon_aurora_access_core_edge_terminal",
+      "name": "Horizon Aurora Access Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Horizon Aurora Access Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Vector Aurora Trunk Plus Offering",
+    "description": "Commercial offering for Vector Aurora Trunk Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "vector_aurora_trunk_plus",
+      "name": "Vector Aurora Trunk Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "vector_aurora_trunk_plus_managed_service",
+      "name": "Vector Aurora Trunk Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "vector_aurora_trunk_plus_edge_terminal",
+      "name": "Vector Aurora Trunk Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Vector Aurora Trunk Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Lumen Aurora Relay Max Offering",
+    "description": "Commercial offering for Lumen Aurora Relay Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "lumen_aurora_relay_max",
+      "name": "Lumen Aurora Relay Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "lumen_aurora_relay_max_managed_service",
+      "name": "Lumen Aurora Relay Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "lumen_aurora_relay_max_edge_terminal",
+      "name": "Lumen Aurora Relay Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Lumen Aurora Relay Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Pioneer Aurora Beam Core Offering",
+    "description": "Commercial offering for Pioneer Aurora Beam Core with a 30-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "pioneer_aurora_beam_core",
+      "name": "Pioneer Aurora Beam Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "pioneer_aurora_beam_core_managed_service",
+      "name": "Pioneer Aurora Beam Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "pioneer_aurora_beam_core_edge_terminal",
+      "name": "Pioneer Aurora Beam Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Pioneer Aurora Beam Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 255
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOfferings/blue_meridian_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/blue_meridian_productOffering.json
@@ -1,0 +1,242 @@
+[
+  {
+    "name": "Vector Blue Trunk Core Offering",
+    "description": "Commercial offering for Vector Blue Trunk Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "vector_blue_trunk_core",
+      "name": "Vector Blue Trunk Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "vector_blue_trunk_core_managed_service",
+      "name": "Vector Blue Trunk Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "vector_blue_trunk_core_edge_terminal",
+      "name": "Vector Blue Trunk Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Vector Blue Trunk Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Lumen Blue Relay Plus Offering",
+    "description": "Commercial offering for Lumen Blue Relay Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "lumen_blue_relay_plus",
+      "name": "Lumen Blue Relay Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "lumen_blue_relay_plus_managed_service",
+      "name": "Lumen Blue Relay Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "lumen_blue_relay_plus_edge_terminal",
+      "name": "Lumen Blue Relay Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Lumen Blue Relay Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Pioneer Blue Beam Max Offering",
+    "description": "Commercial offering for Pioneer Blue Beam Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "pioneer_blue_beam_max",
+      "name": "Pioneer Blue Beam Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "pioneer_blue_beam_max_managed_service",
+      "name": "Pioneer Blue Beam Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "pioneer_blue_beam_max_edge_terminal",
+      "name": "Pioneer Blue Beam Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Pioneer Blue Beam Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Horizon Blue Access Core Offering",
+    "description": "Commercial offering for Horizon Blue Access Core with a 30-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "horizon_blue_access_core",
+      "name": "Horizon Blue Access Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "horizon_blue_access_core_managed_service",
+      "name": "Horizon Blue Access Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "horizon_blue_access_core_edge_terminal",
+      "name": "Horizon Blue Access Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Horizon Blue Access Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 255
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOfferings/cedar_orbit_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/cedar_orbit_productOffering.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "Pioneer Cedar Beam Core Offering",
+    "description": "Commercial offering for Pioneer Cedar Beam Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "pioneer_cedar_beam_core",
+      "name": "Pioneer Cedar Beam Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "pioneer_cedar_beam_core_managed_service",
+      "name": "Pioneer Cedar Beam Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "pioneer_cedar_beam_core_edge_terminal",
+      "name": "Pioneer Cedar Beam Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Pioneer Cedar Beam Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Horizon Cedar Access Plus Offering",
+    "description": "Commercial offering for Horizon Cedar Access Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "horizon_cedar_access_plus",
+      "name": "Horizon Cedar Access Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "horizon_cedar_access_plus_managed_service",
+      "name": "Horizon Cedar Access Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "horizon_cedar_access_plus_edge_terminal",
+      "name": "Horizon Cedar Access Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Horizon Cedar Access Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Vector Cedar Trunk Max Offering",
+    "description": "Commercial offering for Vector Cedar Trunk Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "vector_cedar_trunk_max",
+      "name": "Vector Cedar Trunk Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "vector_cedar_trunk_max_managed_service",
+      "name": "Vector Cedar Trunk Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "vector_cedar_trunk_max_edge_terminal",
+      "name": "Vector Cedar Trunk Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Vector Cedar Trunk Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOfferings/harbor_vector_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/harbor_vector_productOffering.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "Lumen Harbor Relay Core Offering",
+    "description": "Commercial offering for Lumen Harbor Relay Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "lumen_harbor_relay_core",
+      "name": "Lumen Harbor Relay Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "lumen_harbor_relay_core_managed_service",
+      "name": "Lumen Harbor Relay Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "lumen_harbor_relay_core_edge_terminal",
+      "name": "Lumen Harbor Relay Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Lumen Harbor Relay Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Pioneer Harbor Beam Plus Offering",
+    "description": "Commercial offering for Pioneer Harbor Beam Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "pioneer_harbor_beam_plus",
+      "name": "Pioneer Harbor Beam Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "pioneer_harbor_beam_plus_managed_service",
+      "name": "Pioneer Harbor Beam Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "pioneer_harbor_beam_plus_edge_terminal",
+      "name": "Pioneer Harbor Beam Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Pioneer Harbor Beam Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Horizon Harbor Access Max Offering",
+    "description": "Commercial offering for Horizon Harbor Access Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "horizon_harbor_access_max",
+      "name": "Horizon Harbor Access Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "horizon_harbor_access_max_managed_service",
+      "name": "Horizon Harbor Access Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "horizon_harbor_access_max_edge_terminal",
+      "name": "Horizon Harbor Access Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Horizon Harbor Access Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOfferings/northstar_signal_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/northstar_signal_productOffering.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "Lumen Northstar Relay Core Offering",
+    "description": "Commercial offering for Lumen Northstar Relay Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "lumen_northstar_relay_core",
+      "name": "Lumen Northstar Relay Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "lumen_northstar_relay_core_managed_service",
+      "name": "Lumen Northstar Relay Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "lumen_northstar_relay_core_edge_terminal",
+      "name": "Lumen Northstar Relay Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Lumen Northstar Relay Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Pioneer Northstar Beam Plus Offering",
+    "description": "Commercial offering for Pioneer Northstar Beam Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "pioneer_northstar_beam_plus",
+      "name": "Pioneer Northstar Beam Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "pioneer_northstar_beam_plus_managed_service",
+      "name": "Pioneer Northstar Beam Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "pioneer_northstar_beam_plus_edge_terminal",
+      "name": "Pioneer Northstar Beam Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Pioneer Northstar Beam Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Horizon Northstar Access Max Offering",
+    "description": "Commercial offering for Horizon Northstar Access Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "horizon_northstar_access_max",
+      "name": "Horizon Northstar Access Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "horizon_northstar_access_max_managed_service",
+      "name": "Horizon Northstar Access Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "horizon_northstar_access_max_edge_terminal",
+      "name": "Horizon Northstar Access Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Horizon Northstar Access Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOfferings/solstice_array_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/solstice_array_productOffering.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "Vector Solstice Trunk Core Offering",
+    "description": "Commercial offering for Vector Solstice Trunk Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "vector_solstice_trunk_core",
+      "name": "Vector Solstice Trunk Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "vector_solstice_trunk_core_managed_service",
+      "name": "Vector Solstice Trunk Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "vector_solstice_trunk_core_edge_terminal",
+      "name": "Vector Solstice Trunk Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Vector Solstice Trunk Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Lumen Solstice Relay Plus Offering",
+    "description": "Commercial offering for Lumen Solstice Relay Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "lumen_solstice_relay_plus",
+      "name": "Lumen Solstice Relay Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "lumen_solstice_relay_plus_managed_service",
+      "name": "Lumen Solstice Relay Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "lumen_solstice_relay_plus_edge_terminal",
+      "name": "Lumen Solstice Relay Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Lumen Solstice Relay Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Pioneer Solstice Beam Max Offering",
+    "description": "Commercial offering for Pioneer Solstice Beam Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "pioneer_solstice_beam_max",
+      "name": "Pioneer Solstice Beam Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "pioneer_solstice_beam_max_managed_service",
+      "name": "Pioneer Solstice Beam Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "pioneer_solstice_beam_max_edge_terminal",
+      "name": "Pioneer Solstice Beam Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Pioneer Solstice Beam Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOfferings/vela_connect_productOffering.json
+++ b/aiv/testing/testdata/productOfferings/vela_connect_productOffering.json
@@ -1,0 +1,182 @@
+[
+  {
+    "name": "Horizon Vela Access Core Offering",
+    "description": "Commercial offering for Horizon Vela Access Core with a 12-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "horizon_vela_access_core",
+      "name": "Horizon Vela Access Core",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "horizon_vela_access_core_managed_service",
+      "name": "Horizon Vela Access Core Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "horizon_vela_access_core_edge_terminal",
+      "name": "Horizon Vela Access Core Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Horizon Vela Access Core Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 120
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Vector Vela Trunk Plus Offering",
+    "description": "Commercial offering for Vector Vela Trunk Plus with a 18-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "vector_vela_trunk_plus",
+      "name": "Vector Vela Trunk Plus",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "vector_vela_trunk_plus_managed_service",
+      "name": "Vector Vela Trunk Plus Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "vector_vela_trunk_plus_edge_terminal",
+      "name": "Vector Vela Trunk Plus Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Vector Vela Trunk Plus Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 165
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  },
+  {
+    "name": "Lumen Vela Relay Max Offering",
+    "description": "Commercial offering for Lumen Vela Relay Max with a 24-month term.",
+    "isBundle": false,
+    "isSellable": true,
+    "lifecycleStatus": "Active",
+    "statusReason": "Available for synthetic test scenarios",
+    "version": "1.0",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-01-01T00:00:00.000Z"
+    },
+    "productSpecification": {
+      "id": "lumen_vela_relay_max",
+      "name": "Lumen Vela Relay Max",
+      "version": "1.0",
+      "@type": "ProductSpecificationRef",
+      "@referredType": "ProductSpecification"
+    },
+    "serviceCandidate": {
+      "id": "lumen_vela_relay_max_managed_service",
+      "name": "Lumen Vela Relay Max Managed Service",
+      "version": "1.0",
+      "@type": "ServiceCandidateRef",
+      "@referredType": "ServiceSpecification"
+    },
+    "resourceCandidate": {
+      "id": "lumen_vela_relay_max_edge_terminal",
+      "name": "Lumen Vela Relay Max Edge Terminal",
+      "version": "1.0",
+      "@type": "ResourceCandidateRef",
+      "@referredType": "ResourceCandidate"
+    },
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Seller",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "productOfferingPrice": [
+      {
+        "name": "Lumen Vela Relay Max Offering Monthly Price",
+        "priceType": "recurring",
+        "price": {
+          "taxIncludedAmount": {
+            "unit": "EUR",
+            "value": 210
+          }
+        },
+        "@type": "ProductOfferingPrice"
+      }
+    ],
+    "@type": "ProductOffering"
+  }
+]

--- a/aiv/testing/testdata/productOrders/synthetic_product_orders.json
+++ b/aiv/testing/testdata/productOrders/synthetic_product_orders.json
@@ -1,0 +1,234 @@
+[
+  {
+    "category": "Synthetic connectivity order",
+    "description": "Synthetic order for Horizon Aurora Access Core Offering",
+    "priority": "1",
+    "requestedCompletionDate": "2026-01-06T00:00:00.000Z",
+    "requestedStartDate": "2026-01-03T00:00:00.000Z",
+    "note": [
+      {
+        "id": "note-0001",
+        "author": "Mira Keller",
+        "date": "2026-01-01T00:00:00.000Z",
+        "text": "Generated test order note",
+        "@type": "Note"
+      }
+    ],
+    "productOrderItem": [
+      {
+        "id": "item-0001",
+        "quantity": 1,
+        "action": "add",
+        "productOffering": {
+          "id": "horizon_aurora_access_core_offering",
+          "name": "Horizon Aurora Access Core Offering",
+          "version": "1.0",
+          "@type": "ProductOfferingRef",
+          "@referredType": "ProductOffering"
+        },
+        "product": {
+          "startDate": "2026-01-03T00:00:00.000Z",
+          "@type": "Product"
+        },
+        "@type": "ProductOrderItem"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Broker",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      },
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Customer",
+        "partyOrPartyRole": {
+          "id": "mira_keller",
+          "name": "Mira Keller",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ],
+    "@type": "ProductOrder"
+  },
+  {
+    "category": "Synthetic connectivity order",
+    "description": "Synthetic order for Vector Aurora Trunk Plus Offering",
+    "priority": "2",
+    "requestedCompletionDate": "2026-01-09T00:00:00.000Z",
+    "requestedStartDate": "2026-01-06T00:00:00.000Z",
+    "note": [
+      {
+        "id": "note-0002",
+        "author": "Daniel Novak",
+        "date": "2026-01-04T00:00:00.000Z",
+        "text": "Generated test order note",
+        "@type": "Note"
+      }
+    ],
+    "productOrderItem": [
+      {
+        "id": "item-0002",
+        "quantity": 1,
+        "action": "add",
+        "productOffering": {
+          "id": "vector_aurora_trunk_plus_offering",
+          "name": "Vector Aurora Trunk Plus Offering",
+          "version": "1.0",
+          "@type": "ProductOfferingRef",
+          "@referredType": "ProductOffering"
+        },
+        "product": {
+          "startDate": "2026-01-06T00:00:00.000Z",
+          "@type": "Product"
+        },
+        "@type": "ProductOrderItem"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Broker",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      },
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Customer",
+        "partyOrPartyRole": {
+          "id": "daniel_novak",
+          "name": "Daniel Novak",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ],
+    "@type": "ProductOrder"
+  },
+  {
+    "category": "Synthetic connectivity order",
+    "description": "Synthetic order for Lumen Aurora Relay Max Offering",
+    "priority": "3",
+    "requestedCompletionDate": "2026-01-12T00:00:00.000Z",
+    "requestedStartDate": "2026-01-09T00:00:00.000Z",
+    "note": [
+      {
+        "id": "note-0003",
+        "author": "Mira Keller",
+        "date": "2026-01-07T00:00:00.000Z",
+        "text": "Generated test order note",
+        "@type": "Note"
+      }
+    ],
+    "productOrderItem": [
+      {
+        "id": "item-0003",
+        "quantity": 1,
+        "action": "add",
+        "productOffering": {
+          "id": "lumen_aurora_relay_max_offering",
+          "name": "Lumen Aurora Relay Max Offering",
+          "version": "1.0",
+          "@type": "ProductOfferingRef",
+          "@referredType": "ProductOffering"
+        },
+        "product": {
+          "startDate": "2026-01-09T00:00:00.000Z",
+          "@type": "Product"
+        },
+        "@type": "ProductOrderItem"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Broker",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      },
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Customer",
+        "partyOrPartyRole": {
+          "id": "mira_keller",
+          "name": "Mira Keller",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ],
+    "@type": "ProductOrder"
+  },
+  {
+    "category": "Synthetic connectivity order",
+    "description": "Synthetic order for Pioneer Aurora Beam Core Offering",
+    "priority": "1",
+    "requestedCompletionDate": "2026-01-15T00:00:00.000Z",
+    "requestedStartDate": "2026-01-12T00:00:00.000Z",
+    "note": [
+      {
+        "id": "note-0004",
+        "author": "Daniel Novak",
+        "date": "2026-01-10T00:00:00.000Z",
+        "text": "Generated test order note",
+        "@type": "Note"
+      }
+    ],
+    "productOrderItem": [
+      {
+        "id": "item-0004",
+        "quantity": 1,
+        "action": "add",
+        "productOffering": {
+          "id": "pioneer_aurora_beam_core_offering",
+          "name": "Pioneer Aurora Beam Core Offering",
+          "version": "1.0",
+          "@type": "ProductOfferingRef",
+          "@referredType": "ProductOffering"
+        },
+        "product": {
+          "startDate": "2026-01-12T00:00:00.000Z",
+          "@type": "Product"
+        },
+        "@type": "ProductOrderItem"
+      }
+    ],
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Broker",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      },
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "Customer",
+        "partyOrPartyRole": {
+          "id": "daniel_novak",
+          "name": "Daniel Novak",
+          "@type": "PartyRef",
+          "@referredType": "Individual"
+        }
+      }
+    ],
+    "@type": "ProductOrder"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/aurora_relay_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/aurora_relay_productSpecification.json
@@ -1,0 +1,342 @@
+[
+  {
+    "name": "Horizon Aurora Access Core",
+    "brand": "Aurora Relay",
+    "productNumber": "AURO-HORIZON-01",
+    "description": "Horizon Aurora Access Core provides fictional access connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "horizon_aurora_access_core_managed_service",
+        "name": "Horizon Aurora Access Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_aurora_access_core_edge_terminal",
+        "name": "Horizon Aurora Access Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Vector Aurora Trunk Plus",
+    "brand": "Aurora Relay",
+    "productNumber": "AURO-VECTOR-02",
+    "description": "Vector Aurora Trunk Plus provides fictional trunk connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "vector_aurora_trunk_plus_managed_service",
+        "name": "Vector Aurora Trunk Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_aurora_trunk_plus_edge_terminal",
+        "name": "Vector Aurora Trunk Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Lumen Aurora Relay Max",
+    "brand": "Aurora Relay",
+    "productNumber": "AURO-LUMEN-03",
+    "description": "Lumen Aurora Relay Max provides fictional relay connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "lumen_aurora_relay_max_managed_service",
+        "name": "Lumen Aurora Relay Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_aurora_relay_max_edge_terminal",
+        "name": "Lumen Aurora Relay Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Pioneer Aurora Beam Core",
+    "brand": "Aurora Relay",
+    "productNumber": "AURO-PIONEER-04",
+    "description": "Pioneer Aurora Beam Core provides fictional beam connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "pioneer_aurora_beam_core_managed_service",
+        "name": "Pioneer Aurora Beam Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_aurora_beam_core_edge_terminal",
+        "name": "Pioneer Aurora Beam Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 125,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/blue_meridian_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/blue_meridian_productSpecification.json
@@ -1,0 +1,342 @@
+[
+  {
+    "name": "Vector Blue Trunk Core",
+    "brand": "Blue Meridian",
+    "productNumber": "BLUE-VECTOR-01",
+    "description": "Vector Blue Trunk Core provides fictional trunk connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "vector_blue_trunk_core_managed_service",
+        "name": "Vector Blue Trunk Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_blue_trunk_core_edge_terminal",
+        "name": "Vector Blue Trunk Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Lumen Blue Relay Plus",
+    "brand": "Blue Meridian",
+    "productNumber": "BLUE-LUMEN-02",
+    "description": "Lumen Blue Relay Plus provides fictional relay connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "lumen_blue_relay_plus_managed_service",
+        "name": "Lumen Blue Relay Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_blue_relay_plus_edge_terminal",
+        "name": "Lumen Blue Relay Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Pioneer Blue Beam Max",
+    "brand": "Blue Meridian",
+    "productNumber": "BLUE-PIONEER-03",
+    "description": "Pioneer Blue Beam Max provides fictional beam connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "pioneer_blue_beam_max_managed_service",
+        "name": "Pioneer Blue Beam Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_blue_beam_max_edge_terminal",
+        "name": "Pioneer Blue Beam Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Horizon Blue Access Core",
+    "brand": "Blue Meridian",
+    "productNumber": "BLUE-HORIZON-04",
+    "description": "Horizon Blue Access Core provides fictional access connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "horizon_blue_access_core_managed_service",
+        "name": "Horizon Blue Access Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_blue_access_core_edge_terminal",
+        "name": "Horizon Blue Access Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 125,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/cedar_orbit_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/cedar_orbit_productSpecification.json
@@ -1,0 +1,257 @@
+[
+  {
+    "name": "Pioneer Cedar Beam Core",
+    "brand": "Cedar Orbit",
+    "productNumber": "CEDA-PIONEER-01",
+    "description": "Pioneer Cedar Beam Core provides fictional beam connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "pioneer_cedar_beam_core_managed_service",
+        "name": "Pioneer Cedar Beam Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_cedar_beam_core_edge_terminal",
+        "name": "Pioneer Cedar Beam Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Horizon Cedar Access Plus",
+    "brand": "Cedar Orbit",
+    "productNumber": "CEDA-HORIZON-02",
+    "description": "Horizon Cedar Access Plus provides fictional access connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "horizon_cedar_access_plus_managed_service",
+        "name": "Horizon Cedar Access Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_cedar_access_plus_edge_terminal",
+        "name": "Horizon Cedar Access Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Vector Cedar Trunk Max",
+    "brand": "Cedar Orbit",
+    "productNumber": "CEDA-VECTOR-03",
+    "description": "Vector Cedar Trunk Max provides fictional trunk connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "vector_cedar_trunk_max_managed_service",
+        "name": "Vector Cedar Trunk Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_cedar_trunk_max_edge_terminal",
+        "name": "Vector Cedar Trunk Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/harbor_vector_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/harbor_vector_productSpecification.json
@@ -1,0 +1,257 @@
+[
+  {
+    "name": "Lumen Harbor Relay Core",
+    "brand": "Harbor Vector",
+    "productNumber": "HARB-LUMEN-01",
+    "description": "Lumen Harbor Relay Core provides fictional relay connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "lumen_harbor_relay_core_managed_service",
+        "name": "Lumen Harbor Relay Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_harbor_relay_core_edge_terminal",
+        "name": "Lumen Harbor Relay Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Pioneer Harbor Beam Plus",
+    "brand": "Harbor Vector",
+    "productNumber": "HARB-PIONEER-02",
+    "description": "Pioneer Harbor Beam Plus provides fictional beam connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "pioneer_harbor_beam_plus_managed_service",
+        "name": "Pioneer Harbor Beam Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_harbor_beam_plus_edge_terminal",
+        "name": "Pioneer Harbor Beam Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Horizon Harbor Access Max",
+    "brand": "Harbor Vector",
+    "productNumber": "HARB-HORIZON-03",
+    "description": "Horizon Harbor Access Max provides fictional access connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "horizon_harbor_access_max_managed_service",
+        "name": "Horizon Harbor Access Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_harbor_access_max_edge_terminal",
+        "name": "Horizon Harbor Access Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/northstar_signal_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/northstar_signal_productSpecification.json
@@ -1,0 +1,257 @@
+[
+  {
+    "name": "Lumen Northstar Relay Core",
+    "brand": "Northstar Signal",
+    "productNumber": "NORT-LUMEN-01",
+    "description": "Lumen Northstar Relay Core provides fictional relay connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "lumen_northstar_relay_core_managed_service",
+        "name": "Lumen Northstar Relay Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_northstar_relay_core_edge_terminal",
+        "name": "Lumen Northstar Relay Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Pioneer Northstar Beam Plus",
+    "brand": "Northstar Signal",
+    "productNumber": "NORT-PIONEER-02",
+    "description": "Pioneer Northstar Beam Plus provides fictional beam connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "pioneer_northstar_beam_plus_managed_service",
+        "name": "Pioneer Northstar Beam Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_northstar_beam_plus_edge_terminal",
+        "name": "Pioneer Northstar Beam Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Horizon Northstar Access Max",
+    "brand": "Northstar Signal",
+    "productNumber": "NORT-HORIZON-03",
+    "description": "Horizon Northstar Access Max provides fictional access connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "horizon_northstar_access_max_managed_service",
+        "name": "Horizon Northstar Access Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_northstar_access_max_edge_terminal",
+        "name": "Horizon Northstar Access Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/solstice_array_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/solstice_array_productSpecification.json
@@ -1,0 +1,257 @@
+[
+  {
+    "name": "Vector Solstice Trunk Core",
+    "brand": "Solstice Array",
+    "productNumber": "SOLS-VECTOR-01",
+    "description": "Vector Solstice Trunk Core provides fictional trunk connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "vector_solstice_trunk_core_managed_service",
+        "name": "Vector Solstice Trunk Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_solstice_trunk_core_edge_terminal",
+        "name": "Vector Solstice Trunk Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Lumen Solstice Relay Plus",
+    "brand": "Solstice Array",
+    "productNumber": "SOLS-LUMEN-02",
+    "description": "Lumen Solstice Relay Plus provides fictional relay connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "lumen_solstice_relay_plus_managed_service",
+        "name": "Lumen Solstice Relay Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_solstice_relay_plus_edge_terminal",
+        "name": "Lumen Solstice Relay Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Pioneer Solstice Beam Max",
+    "brand": "Solstice Array",
+    "productNumber": "SOLS-PIONEER-03",
+    "description": "Pioneer Solstice Beam Max provides fictional beam connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "pioneer_solstice_beam_max_managed_service",
+        "name": "Pioneer Solstice Beam Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_solstice_beam_max_edge_terminal",
+        "name": "Pioneer Solstice Beam Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/productSpecifications/vela_connect_productSpecification.json
+++ b/aiv/testing/testdata/productSpecifications/vela_connect_productSpecification.json
@@ -1,0 +1,257 @@
+[
+  {
+    "name": "Horizon Vela Access Core",
+    "brand": "Vela Connect",
+    "productNumber": "VELA-HORIZON-01",
+    "description": "Horizon Vela Access Core provides fictional access connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "horizon_vela_access_core_managed_service",
+        "name": "Horizon Vela Access Core Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_vela_access_core_edge_terminal",
+        "name": "Horizon Vela Access Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 50,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Vector Vela Trunk Plus",
+    "brand": "Vela Connect",
+    "productNumber": "VELA-VECTOR-02",
+    "description": "Vector Vela Trunk Plus provides fictional trunk connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "vector_vela_trunk_plus_managed_service",
+        "name": "Vector Vela Trunk Plus Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_vela_trunk_plus_edge_terminal",
+        "name": "Vector Vela Trunk Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 75,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  },
+  {
+    "name": "Lumen Vela Relay Max",
+    "brand": "Vela Connect",
+    "productNumber": "VELA-LUMEN-03",
+    "description": "Lumen Vela Relay Max provides fictional relay connectivity with configurable capacity and service monitoring.",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "attachment": [],
+    "bundledProductSpecification": [],
+    "productSpecificationRelationship": [],
+    "serviceSpecification": [
+      {
+        "id": "lumen_vela_relay_max_managed_service",
+        "name": "Lumen Vela Relay Max Managed Service",
+        "version": "1.0",
+        "@type": "ServiceSpecificationRef",
+        "@referredType": "ServiceSpecification"
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_vela_relay_max_edge_terminal",
+        "name": "Lumen Vela Relay Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "productSpecCharacteristic": [
+      {
+        "name": "bandwidth",
+        "description": "Configured service bandwidth",
+        "valueType": "integer",
+        "configurable": true,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "integer",
+            "value": 100,
+            "unitOfMeasure": "Mbps",
+            "@type": "IntegerCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      },
+      {
+        "name": "networkUptime",
+        "description": "Target network availability",
+        "valueType": "double",
+        "configurable": false,
+        "minCardinality": 1,
+        "maxCardinality": 1,
+        "characteristicValueSpecification": [
+          {
+            "isDefault": true,
+            "valueType": "double",
+            "value": 99.5,
+            "unitOfMeasure": "percent (%)",
+            "@type": "NumberCharacteristicValueSpecification"
+          }
+        ],
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ProductSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/aurora_relay_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/aurora_relay_resourceSpecification.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "Horizon Aurora Access Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Horizon Aurora Access Core.",
+    "isBundle": false,
+    "model": "Horizon-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Vector Aurora Trunk Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Vector Aurora Trunk Plus.",
+    "isBundle": false,
+    "model": "Vector-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Lumen Aurora Relay Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Lumen Aurora Relay Max.",
+    "isBundle": false,
+    "model": "Lumen-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Pioneer Aurora Beam Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Pioneer Aurora Beam Core.",
+    "isBundle": false,
+    "model": "Pioneer-04",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/blue_meridian_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/blue_meridian_resourceSpecification.json
@@ -1,0 +1,90 @@
+[
+  {
+    "name": "Vector Blue Trunk Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Vector Blue Trunk Core.",
+    "isBundle": false,
+    "model": "Vector-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Lumen Blue Relay Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Lumen Blue Relay Plus.",
+    "isBundle": false,
+    "model": "Lumen-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Pioneer Blue Beam Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Pioneer Blue Beam Max.",
+    "isBundle": false,
+    "model": "Pioneer-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Horizon Blue Access Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Horizon Blue Access Core.",
+    "isBundle": false,
+    "model": "Horizon-04",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/cedar_orbit_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/cedar_orbit_resourceSpecification.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Pioneer Cedar Beam Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Pioneer Cedar Beam Core.",
+    "isBundle": false,
+    "model": "Pioneer-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Horizon Cedar Access Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Horizon Cedar Access Plus.",
+    "isBundle": false,
+    "model": "Horizon-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Vector Cedar Trunk Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Vector Cedar Trunk Max.",
+    "isBundle": false,
+    "model": "Vector-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/harbor_vector_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/harbor_vector_resourceSpecification.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Lumen Harbor Relay Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Lumen Harbor Relay Core.",
+    "isBundle": false,
+    "model": "Lumen-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Pioneer Harbor Beam Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Pioneer Harbor Beam Plus.",
+    "isBundle": false,
+    "model": "Pioneer-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Horizon Harbor Access Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Horizon Harbor Access Max.",
+    "isBundle": false,
+    "model": "Horizon-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/northstar_signal_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/northstar_signal_resourceSpecification.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Lumen Northstar Relay Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Lumen Northstar Relay Core.",
+    "isBundle": false,
+    "model": "Lumen-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Pioneer Northstar Beam Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Pioneer Northstar Beam Plus.",
+    "isBundle": false,
+    "model": "Pioneer-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Horizon Northstar Access Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Horizon Northstar Access Max.",
+    "isBundle": false,
+    "model": "Horizon-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/solstice_array_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/solstice_array_resourceSpecification.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Vector Solstice Trunk Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Vector Solstice Trunk Core.",
+    "isBundle": false,
+    "model": "Vector-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Lumen Solstice Relay Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Lumen Solstice Relay Plus.",
+    "isBundle": false,
+    "model": "Lumen-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Pioneer Solstice Beam Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Pioneer Solstice Beam Max.",
+    "isBundle": false,
+    "model": "Pioneer-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/resourceSpecifications/vela_connect_resourceSpecification.json
+++ b/aiv/testing/testdata/resourceSpecifications/vela_connect_resourceSpecification.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "Horizon Vela Access Core Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Horizon Vela Access Core.",
+    "isBundle": false,
+    "model": "Horizon-01",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Vector Vela Trunk Plus Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Vector Vela Trunk Plus.",
+    "isBundle": false,
+    "model": "Vector-02",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  },
+  {
+    "name": "Lumen Vela Relay Max Edge Terminal",
+    "category": "Customer edge equipment",
+    "description": "Fictional terminal resource used by Lumen Vela Relay Max.",
+    "isBundle": false,
+    "model": "Lumen-03",
+    "vendor": "Aster Devices",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2029-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "resourceSpecCharacteristic": [
+      {
+        "name": "weight",
+        "valueType": "double",
+        "unitOfMeasure": "kg",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ResourceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/aurora_relay_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/aurora_relay_serviceSpecification.json
@@ -1,0 +1,198 @@
+[
+  {
+    "name": "Horizon Aurora Access Core Managed Service",
+    "description": "Managed delivery for the fictional Horizon Aurora Access Core product.",
+    "id": "horizon_aurora_access_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Horizon Aurora Access Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "horizon_aurora_access_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/horizon_aurora_access_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_aurora_access_core_edge_terminal",
+        "name": "Horizon Aurora Access Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Vector Aurora Trunk Plus Managed Service",
+    "description": "Managed delivery for the fictional Vector Aurora Trunk Plus product.",
+    "id": "vector_aurora_trunk_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Vector Aurora Trunk Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "vector_aurora_trunk_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/vector_aurora_trunk_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_aurora_trunk_plus_edge_terminal",
+        "name": "Vector Aurora Trunk Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Lumen Aurora Relay Max Managed Service",
+    "description": "Managed delivery for the fictional Lumen Aurora Relay Max product.",
+    "id": "lumen_aurora_relay_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Lumen Aurora Relay Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "lumen_aurora_relay_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/lumen_aurora_relay_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_aurora_relay_max_edge_terminal",
+        "name": "Lumen Aurora Relay Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Pioneer Aurora Beam Core Managed Service",
+    "description": "Managed delivery for the fictional Pioneer Aurora Beam Core product.",
+    "id": "pioneer_aurora_beam_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Pioneer Aurora Beam Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "pioneer_aurora_beam_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/pioneer_aurora_beam_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "aurora_relay",
+          "name": "Aurora Relay",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_aurora_beam_core_edge_terminal",
+        "name": "Pioneer Aurora Beam Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/blue_meridian_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/blue_meridian_serviceSpecification.json
@@ -1,0 +1,198 @@
+[
+  {
+    "name": "Vector Blue Trunk Core Managed Service",
+    "description": "Managed delivery for the fictional Vector Blue Trunk Core product.",
+    "id": "vector_blue_trunk_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Vector Blue Trunk Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "vector_blue_trunk_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/vector_blue_trunk_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_blue_trunk_core_edge_terminal",
+        "name": "Vector Blue Trunk Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Lumen Blue Relay Plus Managed Service",
+    "description": "Managed delivery for the fictional Lumen Blue Relay Plus product.",
+    "id": "lumen_blue_relay_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Lumen Blue Relay Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "lumen_blue_relay_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/lumen_blue_relay_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_blue_relay_plus_edge_terminal",
+        "name": "Lumen Blue Relay Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Pioneer Blue Beam Max Managed Service",
+    "description": "Managed delivery for the fictional Pioneer Blue Beam Max product.",
+    "id": "pioneer_blue_beam_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Pioneer Blue Beam Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "pioneer_blue_beam_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/pioneer_blue_beam_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_blue_beam_max_edge_terminal",
+        "name": "Pioneer Blue Beam Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Horizon Blue Access Core Managed Service",
+    "description": "Managed delivery for the fictional Horizon Blue Access Core product.",
+    "id": "horizon_blue_access_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Horizon Blue Access Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "horizon_blue_access_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/horizon_blue_access_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "blue_meridian",
+          "name": "Blue Meridian",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_blue_access_core_edge_terminal",
+        "name": "Horizon Blue Access Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/cedar_orbit_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/cedar_orbit_serviceSpecification.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "Pioneer Cedar Beam Core Managed Service",
+    "description": "Managed delivery for the fictional Pioneer Cedar Beam Core product.",
+    "id": "pioneer_cedar_beam_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Pioneer Cedar Beam Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "pioneer_cedar_beam_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/pioneer_cedar_beam_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_cedar_beam_core_edge_terminal",
+        "name": "Pioneer Cedar Beam Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Horizon Cedar Access Plus Managed Service",
+    "description": "Managed delivery for the fictional Horizon Cedar Access Plus product.",
+    "id": "horizon_cedar_access_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Horizon Cedar Access Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "horizon_cedar_access_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/horizon_cedar_access_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_cedar_access_plus_edge_terminal",
+        "name": "Horizon Cedar Access Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Vector Cedar Trunk Max Managed Service",
+    "description": "Managed delivery for the fictional Vector Cedar Trunk Max product.",
+    "id": "vector_cedar_trunk_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Vector Cedar Trunk Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "vector_cedar_trunk_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/vector_cedar_trunk_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "cedar_orbit",
+          "name": "Cedar Orbit",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_cedar_trunk_max_edge_terminal",
+        "name": "Vector Cedar Trunk Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/harbor_vector_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/harbor_vector_serviceSpecification.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "Lumen Harbor Relay Core Managed Service",
+    "description": "Managed delivery for the fictional Lumen Harbor Relay Core product.",
+    "id": "lumen_harbor_relay_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Lumen Harbor Relay Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "lumen_harbor_relay_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/lumen_harbor_relay_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_harbor_relay_core_edge_terminal",
+        "name": "Lumen Harbor Relay Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Pioneer Harbor Beam Plus Managed Service",
+    "description": "Managed delivery for the fictional Pioneer Harbor Beam Plus product.",
+    "id": "pioneer_harbor_beam_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Pioneer Harbor Beam Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "pioneer_harbor_beam_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/pioneer_harbor_beam_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_harbor_beam_plus_edge_terminal",
+        "name": "Pioneer Harbor Beam Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Horizon Harbor Access Max Managed Service",
+    "description": "Managed delivery for the fictional Horizon Harbor Access Max product.",
+    "id": "horizon_harbor_access_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Horizon Harbor Access Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "horizon_harbor_access_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/horizon_harbor_access_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "harbor_vector",
+          "name": "Harbor Vector",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_harbor_access_max_edge_terminal",
+        "name": "Horizon Harbor Access Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/northstar_signal_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/northstar_signal_serviceSpecification.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "Lumen Northstar Relay Core Managed Service",
+    "description": "Managed delivery for the fictional Lumen Northstar Relay Core product.",
+    "id": "lumen_northstar_relay_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Lumen Northstar Relay Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "lumen_northstar_relay_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/lumen_northstar_relay_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_northstar_relay_core_edge_terminal",
+        "name": "Lumen Northstar Relay Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Pioneer Northstar Beam Plus Managed Service",
+    "description": "Managed delivery for the fictional Pioneer Northstar Beam Plus product.",
+    "id": "pioneer_northstar_beam_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Pioneer Northstar Beam Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "pioneer_northstar_beam_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/pioneer_northstar_beam_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_northstar_beam_plus_edge_terminal",
+        "name": "Pioneer Northstar Beam Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Horizon Northstar Access Max Managed Service",
+    "description": "Managed delivery for the fictional Horizon Northstar Access Max product.",
+    "id": "horizon_northstar_access_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Horizon Northstar Access Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "horizon_northstar_access_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/horizon_northstar_access_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "northstar_signal",
+          "name": "Northstar Signal",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_northstar_access_max_edge_terminal",
+        "name": "Horizon Northstar Access Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/solstice_array_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/solstice_array_serviceSpecification.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "Vector Solstice Trunk Core Managed Service",
+    "description": "Managed delivery for the fictional Vector Solstice Trunk Core product.",
+    "id": "vector_solstice_trunk_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Vector Solstice Trunk Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "vector_solstice_trunk_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/vector_solstice_trunk_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_solstice_trunk_core_edge_terminal",
+        "name": "Vector Solstice Trunk Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Lumen Solstice Relay Plus Managed Service",
+    "description": "Managed delivery for the fictional Lumen Solstice Relay Plus product.",
+    "id": "lumen_solstice_relay_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Lumen Solstice Relay Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "lumen_solstice_relay_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/lumen_solstice_relay_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_solstice_relay_plus_edge_terminal",
+        "name": "Lumen Solstice Relay Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Pioneer Solstice Beam Max Managed Service",
+    "description": "Managed delivery for the fictional Pioneer Solstice Beam Max product.",
+    "id": "pioneer_solstice_beam_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Pioneer Solstice Beam Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "pioneer_solstice_beam_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/pioneer_solstice_beam_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "solstice_array",
+          "name": "Solstice Array",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "pioneer_solstice_beam_max_edge_terminal",
+        "name": "Pioneer Solstice Beam Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/aiv/testing/testdata/serviceSpecifications/vela_connect_serviceSpecification.json
+++ b/aiv/testing/testdata/serviceSpecifications/vela_connect_serviceSpecification.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": "Horizon Vela Access Core Managed Service",
+    "description": "Managed delivery for the fictional Horizon Vela Access Core product.",
+    "id": "horizon_vela_access_core_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Horizon Vela Access Core Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "horizon_vela_access_core",
+    "parentSpecificationHref": "https://example.invalid/specifications/horizon_vela_access_core",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "horizon_vela_access_core_edge_terminal",
+        "name": "Horizon Vela Access Core Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Vector Vela Trunk Plus Managed Service",
+    "description": "Managed delivery for the fictional Vector Vela Trunk Plus product.",
+    "id": "vector_vela_trunk_plus_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Vector Vela Trunk Plus Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "vector_vela_trunk_plus",
+    "parentSpecificationHref": "https://example.invalid/specifications/vector_vela_trunk_plus",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "vector_vela_trunk_plus_edge_terminal",
+        "name": "Vector Vela Trunk Plus Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  },
+  {
+    "name": "Lumen Vela Relay Max Managed Service",
+    "description": "Managed delivery for the fictional Lumen Vela Relay Max product.",
+    "id": "lumen_vela_relay_max_managed_service",
+    "entity": "ServiceSpecification",
+    "value": "Lumen Vela Relay Max Managed Service",
+    "valueType": "string",
+    "relationshipType": "uses",
+    "parentSpecificationId": "lumen_vela_relay_max",
+    "parentSpecificationHref": "https://example.invalid/specifications/lumen_vela_relay_max",
+    "@referredType": "ServiceSpecification",
+    "@schemaLocation": "https://example.invalid/schemas/service-specification.json",
+    "isBundle": false,
+    "lifecycleStatus": "Active",
+    "validFor": {
+      "startDateTime": "2026-01-01T00:00:00.000Z",
+      "endDateTime": "2028-12-31T00:00:00.000Z"
+    },
+    "version": "1.0",
+    "relatedParty": [
+      {
+        "@type": "RelatedPartyRefOrPartyRoleRef",
+        "role": "ServiceProvider",
+        "partyOrPartyRole": {
+          "id": "vela_connect",
+          "name": "Vela Connect",
+          "@type": "PartyRef",
+          "@referredType": "Organization"
+        }
+      }
+    ],
+    "resourceSpecification": [
+      {
+        "id": "lumen_vela_relay_max_edge_terminal",
+        "name": "Lumen Vela Relay Max Edge Terminal",
+        "version": "1.0",
+        "@type": "ResourceSpecificationRef",
+        "@referredType": "PhysicalResourceSpecification"
+      }
+    ],
+    "specCharacteristic": [
+      {
+        "name": "serviceLevel",
+        "valueType": "string",
+        "@type": "CharacteristicSpecification"
+      }
+    ],
+    "@type": "ServiceSpecification"
+  }
+]

--- a/source/psid-mockup/build.gradle
+++ b/source/psid-mockup/build.gradle
@@ -11,7 +11,9 @@ dependencies {
   implementation('org.springframework.boot:spring-boot-starter-data-mongodb')
   implementation('org.springframework.boot:spring-boot-starter-webflux')
   implementation('org.springdoc:springdoc-openapi-ui')
-  testRuntimeOnly('de.flapdoodle.embed:de.flapdoodle.embed.mongo')
+  testRuntimeOnly('de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.33.0')
+  testRuntimeOnly('de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring27x:4.33.0')
+  testRuntimeOnly('org.apache.commons:commons-lang3:3.18.0')
   testImplementation('com.squareup.okhttp3:mockwebserver')
 }
 

--- a/source/psid-mockup/src/test/java/com/cgi/space/psi/pss/stub/demodata/DemoDataLoaderTest.java
+++ b/source/psid-mockup/src/test/java/com/cgi/space/psi/pss/stub/demodata/DemoDataLoaderTest.java
@@ -28,7 +28,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@SpringBootTest(properties = "psi.demo-data.path=../../aiv/testing/aitf/testdata/")
+@SpringBootTest(properties = "psi.demo-data.path=../../aiv/testing/testdata/")
 public class DemoDataLoaderTest {
 
     @Autowired

--- a/source/psid-mockup/src/test/resources/application.yml
+++ b/source/psid-mockup/src/test/resources/application.yml
@@ -1,7 +1,8 @@
-spring:
-  mongodb:
-    embedded:
-      version: 5.0.6
+de:
+  flapdoodle:
+    mongodb:
+      embedded:
+        version: 8.0.23
 
 psi:
   provider-stub:


### PR DESCRIPTION
- Switch to de.flapdoodle.embed.mongo:4.33.0 which supports Ubuntu 26.04
- Use flapdoodle.embed.mongo.spring27x for Spring Boot 2.7.x support
- Force usage of commons-lang3:3.18.0 during test execution for compatibility with new de.flapdoodle.embed.mongo
- Restore test data from old PSI repository to fix DemoDataLoaderTest and AlarmApiIT